### PR TITLE
change travis file to use newer R lang setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-language: c
-script: "./travis-tool.sh run_tests"
-before_script:
-- curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-- chmod 755 ./travis-tool.sh
-- "./travis-tool.sh bootstrap"
-- "./travis-tool.sh install_deps"
+language: r
+sudo: false
+cache: packages


### PR DESCRIPTION
and cache: packages, sudo: false to speed up builds

hey @abaghan  - going through all ropensci repos trying to speed up Travis builds by using container based builds whenever possible 

the build https://travis-ci.org/ropensci/rGEM/builds/209168353 isn't faster than the others on the first run, but should be faster the next time since deps are cached

docs for R language on travis https://docs.travis-ci.com/user/languages/r